### PR TITLE
Allow intra-VPN networking

### DIFF
--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -181,8 +181,8 @@ else
 	# Avoid an unneeded reboot
 	echo 1 > /proc/sys/net/ipv4/ip_forward
 	# Set iptables
-	iptables -t nat -A POSTROUTING -s 10.8.0.0/24 -j SNAT --to $IP
-	sed -i "/# By default this script does nothing./a\iptables -t nat -A POSTROUTING -s 10.8.0.0/24 -j SNAT --to $IP" /etc/rc.local
+	iptables -t nat -A POSTROUTING -s 10.8.0.0/24 ! -d 10.8.0.0/24 -j SNAT --to $IP
+	sed -i "/# By default this script does nothing./a\iptables -t nat -A POSTROUTING -s 10.8.0.0/24 ! -d 10.8.0.0/24 -j SNAT --to $IP" /etc/rc.local
 	# And finally, restart OpenVPN
 	/etc/init.d/openvpn restart
 	# Let's generate the client config


### PR DESCRIPTION
By excluding the internal network from the SNAT route, intra-VPN traffic will be routed correctly.

It might be worth it to add a step to the installation wizard that asks whether the user wants this feature, but I can't see any scenario in which the clients connecting to the VPN wouldn't be trusted. Let me know if you deem this necessary and I'll add another commit that does it.
