### PR TITLE
Clean up client config builder & improve Android/Windows client support

### DIFF
--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -23,6 +23,21 @@ if [[ ! -e /etc/debian_version ]]; then
 	exit
 fi
 
+bundleClient() {
+	# Bundle the client config files and archive them up.
+	# *.ovpn for Android & Windows, *.conf symlink for Linux.
+	mkdir ~/ovpn-$1 && cd $_
+	cp /usr/share/doc/openvpn/examples/sample-config-files/client.conf ./$1.ovpn
+	cp /etc/openvpn/easy-rsa/2.0/keys/ca.crt ./
+	cp /etc/openvpn/easy-rsa/2.0/keys/$1.crt ./
+	cp /etc/openvpn/easy-rsa/2.0/keys/$1.key ./
+	ln -s $1.ovpn $1.conf
+	sed -i "s|cert client.crt|cert $1.crt|" $1.conf
+	sed -i "s|key client.key|key $1.key|" $1.conf
+	tar -czf ../ovpn-$1.tar.gz $1.ovpn $1.conf ca.crt $1.crt $1.key
+	cd ~/
+	rm -rf ovpn-$1
+}
 
 # Try to get our IP from the system and fallback to the Internet.
 # I do this to make the script compatible with NATed servers (lowendspirit.com)
@@ -58,18 +73,8 @@ if [[ -e /etc/openvpn/server.conf ]]; then
 			export KEY_CN="$CLIENT"
 			export EASY_RSA="${EASY_RSA:-.}"
 			"$EASY_RSA/pkitool" $CLIENT
-			# Let's generate the client config
-			mkdir ~/ovpn-$CLIENT
-			cp /usr/share/doc/openvpn/examples/sample-config-files/client.conf ~/ovpn-$CLIENT/$CLIENT.conf
-			cp /etc/openvpn/easy-rsa/2.0/keys/ca.crt ~/ovpn-$CLIENT
-			cp /etc/openvpn/easy-rsa/2.0/keys/$CLIENT.crt ~/ovpn-$CLIENT
-			cp /etc/openvpn/easy-rsa/2.0/keys/$CLIENT.key ~/ovpn-$CLIENT
-			cd ~/ovpn-$CLIENT
-			sed -i "s|cert client.crt|cert $CLIENT.crt|" $CLIENT.conf
-			sed -i "s|key client.key|key $CLIENT.key|" $CLIENT.conf
-			tar -czf ../ovpn-$CLIENT.tar.gz $CLIENT.conf ca.crt $CLIENT.crt $CLIENT.key
-			cd ~/
-			rm -rf ovpn-$CLIENT
+			# Bundle the client config
+			bundleClient "$CLIENT"
 			echo ""
 			echo "Client $CLIENT added, certs available at ~/ovpn-$CLIENT.tar.gz"
 			exit
@@ -193,8 +198,6 @@ else
 	sed -i "/# By default this script does nothing./a\iptables -t nat -A POSTROUTING -s 10.8.0.0/24 -j SNAT --to $IP" /etc/rc.local
 	# And finally, restart OpenVPN
 	/etc/init.d/openvpn restart
-	# Let's generate the client config
-	mkdir ~/ovpn-$CLIENT
 	# Try to detect a NATed connection and ask about it to potential LowEndSpirit
 	# users
 	EXTERNALIP=$(wget -qO- ipv4.icanhazip.com)
@@ -212,16 +215,8 @@ else
 	# IP/port set on the default client.conf so we can add further users
 	# without asking for them
 	sed -i "s|remote my-server-1 1194|remote $IP $PORT|" /usr/share/doc/openvpn/examples/sample-config-files/client.conf
-	cp /usr/share/doc/openvpn/examples/sample-config-files/client.conf ~/ovpn-$CLIENT/$CLIENT.conf
-	cp /etc/openvpn/easy-rsa/2.0/keys/ca.crt ~/ovpn-$CLIENT
-	cp /etc/openvpn/easy-rsa/2.0/keys/$CLIENT.crt ~/ovpn-$CLIENT
-	cp /etc/openvpn/easy-rsa/2.0/keys/$CLIENT.key ~/ovpn-$CLIENT
-	cd ~/ovpn-$CLIENT
-	sed -i "s|cert client.crt|cert $CLIENT.crt|" $CLIENT.conf
-	sed -i "s|key client.key|key $CLIENT.key|" $CLIENT.conf
-	tar -czf ../ovpn-$CLIENT.tar.gz $CLIENT.conf ca.crt $CLIENT.crt $CLIENT.key
-	cd ~/
-	rm -rf ovpn-$CLIENT
+	# Bundle the client config
+	bundleClient "$CLIENT"
 	echo ""
 	echo "Finished!"
 	echo ""


### PR DESCRIPTION
Hey!

I propose the following improvements to the client build|bundle|archive section:
- Combine code used for initial run and code used for later runs into a single function, _bundleClient $CLIENT_. 
- Use relative paths for _cd_ and _cp_ operations. 
- Instead of a single _$CLIENT.conf_ file, generate a _$CLIENT.ovpn_ file (as required by the OpenVPN client for Android and Windows) alongside a _$CLIENT.conf_ symlink (for Linux). 
