### PR TITLE
Make the script POSIX-compliant and init system detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This script will let you setup your own VPN server in no more than a minute, eve
 ###Installation
 Run the script and follow the assistant:
 
-`wget git.io/vpn --no-check-certificate -O openvpn-install.sh && bash openvpn-install.sh`
+`wget git.io/vpn --no-check-certificate -O openvpn-install.sh && sh openvpn-install.sh`
 
 Once it ends, you can run it again to add more users, remove some of them or even completely uninstall OpenVPN.
 

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -12,19 +12,20 @@
 
 if [ "$(id -u)" != "0" ]
 then
-   echo "Sorry, you need to run this as root"
-   exit 1
+	echo "Sorry, you need to run this as root"
+	exit 1
 fi
 
 if [ ! -e /dev/net/tun ]
 then
-  echo "TUN/TAP is not available"
+	echo "TUN/TAP is not available"
 	exit 2
 fi
 
 
 if grep -qs "CentOS release 5" "/etc/redhat-release"
-then echo "CentOS 5 is too old and not supported"
+then
+	echo "CentOS 5 is too old and not supported"
 	exit 3
 fi
 
@@ -49,8 +50,9 @@ pidof /sbin/init && INITSYS=sysvinit
 # Return the PID of systemd if running
 pidof systemd && INITSYS=systemd
 if [ "$INITSYS" = "" ]
-  then echo "Your init system isn't supported"
-  exit 5
+then
+	echo "Your init system isn't supported"
+	exit 5
 fi
 
 newclient() {
@@ -72,7 +74,7 @@ newclient() {
 # and to avoid getting an IPv6.
 IP=$(ip addr | grep 'inet' | grep -v inet6 | grep -vE '127\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}' | grep -o -E '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}' | head -1)
 if [ "$IP" = "" ]
-  then IP=$(wget -qO- ipv4.icanhazip.com)
+	then IP=$(wget -qO- ipv4.icanhazip.com)
 fi
 
 if [ -e /etc/openvpn/server.conf ]
@@ -93,8 +95,8 @@ then
 			echo ""
 			echo "Tell me a name for the client cert"
 			echo "Please, use one word only, no special characters"
-      read -p "Client name: client " CLIENT
-      CLIENT=${CLIENT:-client}
+			read -p "Client name: client " CLIENT
+			CLIENT=${CLIENT:-client}
 			cd /etc/openvpn/easy-rsa/
 			./easyrsa build-client-full $CLIENT nopass
 			# Generates the custom client.ovpn
@@ -107,7 +109,7 @@ then
 			# ...but what can I say, I want some sleep too
 			NUMBEROFCLIENTS=$(tail -n +2 /etc/openvpn/easy-rsa/pki/index.txt | grep -c "^V")
 			if [ "$NUMBEROFCLIENTS" = 0 ]
-      then
+			then
 				echo ""
 				echo "You have no existing clients!"
 				exit 5
@@ -116,7 +118,7 @@ then
 			echo "Select the existing client certificate you want to revoke"
 			tail -n +2 /etc/openvpn/easy-rsa/pki/index.txt | grep "^V" | cut -d '=' -f 2 | nl -s ') '
 			if [ "$NUMBEROFCLIENTS" = 1 ]
-        then read -p "Select one client [1]: " CLIENTNUMBER
+				then read -p "Select one client [1]: " CLIENTNUMBER
 			else
 				read -p "Select one client [1-$NUMBEROFCLIENTS]: " CLIENTNUMBER
 			fi
@@ -126,18 +128,18 @@ then
 			./easyrsa gen-crl
 			# And restart
 			if [ $INITSYS = systemd ]
-        then systemctl restart openvpn@server.service
+				then systemctl restart openvpn@server.service
 			else
-        service openvpn restart
+				service openvpn restart
 			fi
 			echo ""
 			echo "Certificate for client $CLIENT revoked"
 			exit;;
 			3)
 			echo ""
-      read -p "Do you really want to remove OpenVPN? [N/y]: " REMOVE
+			read -p "Do you really want to remove OpenVPN? [N/y]: " REMOVE
 			if [ $REMOVE = y ]
-        then PORT=$(grep '^port ' /etc/openvpn/server.conf | cut -d " " -f 2)
+				then PORT=$(grep '^port ' /etc/openvpn/server.conf | cut -d " " -f 2)
 				if pgrep firewalld
 				then # Using both permanent and not permanent rules to avoid a firewalld reload.
 					firewall-cmd --zone=public --remove-port=$PORT/udp
@@ -153,7 +155,7 @@ then
 				fi
 				sed -i '/iptables -t nat -A POSTROUTING -s 10.8.0.0\/24 -j SNAT --to /d' $RCLOCAL
 				if [ $OS = debian ]
-          then apt-get remove --purge -y openvpn openvpn-blacklist
+					then apt-get remove --purge -y openvpn openvpn-blacklist
 				else
 					yum remove openvpn -y
 				fi
@@ -179,12 +181,12 @@ else
 	echo ""
 	echo "First I need to know the IPv4 address of the network interface you want OpenVPN"
 	echo "listening to."
-  read -p "IP address: $IP " IP
-  IP=${IP:-$IP}
+	read -p "IP address: $IP " IP
+	IP=${IP:-$IP}
 	echo ""
 	echo "What port do you want for OpenVPN?"
 	read -p "Port: 1194 " PORT
-  PORT=${PORT:-1194}
+	PORT=${PORT:-1194}
 	echo ""
 	echo "What DNS do you want to use with the VPN?"
 	echo "   1) Current system resolvers"
@@ -194,18 +196,18 @@ else
 	echo "   5) Hurricane Electric"
 	echo "   6) Google"
 	read -p "DNS [1-6]: 1 " DNS
-  DNS=${DNS:-1}
+	DNS=${DNS:-1}
 	echo ""
 	echo "Finally, tell me your name for the client cert"
 	echo "Please, use one word only, no special characters"
-  read -p "Client name: client " CLIENT
-  CLIENT=${CLIENT:-client}
-  echo ""
+	read -p "Client name: client " CLIENT
+	CLIENT=${CLIENT:-client}
+	echo ""
 	echo "Okay, that was all I needed. We are ready to setup your OpenVPN server now"
-	echo "Press [ENTER] to continue... \c"
-  read
-  if [ $OS = debian ]
-  then
+	echo "Press [ENTER] to continue... \c "
+	read
+	if [ $OS = debian ]
+	then
 		apt-get update
 		apt-get install openvpn iptables openssl ca-certificates -y
 	else
@@ -215,7 +217,7 @@ else
 	fi
 	# An old version of easy-rsa was available by default in some openvpn packages
 	if [ -d /etc/openvpn/easy-rsa/ ]
-    then rm -rf /etc/openvpn/easy-rsa/
+		then rm -rf /etc/openvpn/easy-rsa/
 	fi
 	# Get easy-rsa
 	wget -O ~/EasyRSA-3.0.1.tgz https://github.com/OpenVPN/easy-rsa/releases/download/3.0.1/EasyRSA-3.0.1.tgz
@@ -318,12 +320,12 @@ crl-verify /etc/openvpn/easy-rsa/pki/crl.pem" >> /etc/openvpn/server.conf
 	fi
 	# And finally, restart OpenVPN
 	if [ $INITSYS = systemd ]
-  then # Little hack to check for systemd
-    systemctl restart openvpn@server.service
-    systemctl enable openvpn@server.service
+	then
+		systemctl restart openvpn@server.service
+		systemctl enable openvpn@server.service
 	else
-    service openvpn restart
-    chkconfig openvpn on
+		service openvpn restart
+		chkconfig openvpn on
 	fi
 	# Try to detect a NATed connection and ask about it to potential LowEndSpirit users
 	EXTERNALIP=$(wget -qO- ipv4.icanhazip.com)
@@ -336,7 +338,7 @@ crl-verify /etc/openvpn/easy-rsa/pki/crl.pem" >> /etc/openvpn/server.conf
 		echo "If that's not the case, just ignore this and leave the next field blank"
 		read -p "External IP: " USEREXTERNALIP
 		if [ "$USEREXTERNALIP" != "" ]
-      then echo IP=$USEREXTERNALIP
+			then echo IP=$USEREXTERNALIP
 		fi
 	fi
 	# client-common.txt is created so we have a template to add further users later

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # OpenVPN road warrior installer for Debian, Ubuntu and CentOS
 
 # This script will work on Debian, Ubuntu, CentOS and probably other distros
@@ -8,27 +8,30 @@
 # universal as possible.
 
 
-if [[ "$EUID" -ne 0 ]]; then
-	echo "Sorry, you need to run this as root"
-	exit 1
+if [ "$(id -u)" != "0" ]
+then
+   echo "Sorry, you need to run this as root"
+   exit 1
 fi
 
-
-if [[ ! -e /dev/net/tun ]]; then
-	echo "TUN/TAP is not available"
+if [ ! -e /dev/net/tun ]
+then
+  echo "TUN/TAP is not available"
 	exit 2
 fi
 
 
-if grep -qs "CentOS release 5" "/etc/redhat-release"; then
-	echo "CentOS 5 is too old and not supported"
+if grep -qs "CentOS release 5" "/etc/redhat-release"
+then echo "CentOS 5 is too old and not supported"
 	exit 3
 fi
 
-if [[ -e /etc/debian_version ]]; then
+if [ -e /etc/debian_version ]
+then
 	OS=debian
 	RCLOCAL='/etc/rc.local'
-elif [[ -e /etc/centos-release || -e /etc/redhat-release ]]; then
+elif [ -e /etc/centos-release || -e /etc/redhat-release ]
+then
 	OS=centos
 	RCLOCAL='/etc/rc.d/rc.local'
 	# Needed for CentOS 7
@@ -38,7 +41,7 @@ else
 	exit 4
 fi
 
-newclient () {
+newclient() {
 	# Generates the custom client.ovpn
 	cp /etc/openvpn/client-common.txt ~/$1.ovpn
 	echo "<ca>" >> ~/$1.ovpn
@@ -52,17 +55,16 @@ newclient () {
 	echo "</key>" >> ~/$1.ovpn
 }
 
-
 # Try to get our IP from the system and fallback to the Internet.
 # I do this to make the script compatible with NATed servers (lowendspirit.com)
 # and to avoid getting an IPv6.
 IP=$(ip addr | grep 'inet' | grep -v inet6 | grep -vE '127\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}' | grep -o -E '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}' | head -1)
-if [[ "$IP" = "" ]]; then
-		IP=$(wget -qO- ipv4.icanhazip.com)
+if [ "$IP" = "" ]
+  then IP=$(wget -qO- ipv4.icanhazip.com)
 fi
 
-
-if [[ -e /etc/openvpn/server.conf ]]; then
+if [ -e /etc/openvpn/server.conf ]
+then
 	while :
 	do
 	clear
@@ -75,24 +77,25 @@ if [[ -e /etc/openvpn/server.conf ]]; then
 		echo "   4) Exit"
 		read -p "Select an option [1-4]: " option
 		case $option in
-			1) 
+			1)
 			echo ""
 			echo "Tell me a name for the client cert"
 			echo "Please, use one word only, no special characters"
-			read -p "Client name: " -e -i client CLIENT
+      read -p "Client name: client " CLIENT
+      CLIENT=${CLIENT:-client}
 			cd /etc/openvpn/easy-rsa/
 			./easyrsa build-client-full $CLIENT nopass
 			# Generates the custom client.ovpn
 			newclient "$CLIENT"
 			echo ""
 			echo "Client $CLIENT added, certs available at ~/$CLIENT.ovpn"
-			exit
-			;;
+			exit;;
 			2)
 			# This option could be documented a bit better and maybe even be simplimplified
 			# ...but what can I say, I want some sleep too
 			NUMBEROFCLIENTS=$(tail -n +2 /etc/openvpn/easy-rsa/pki/index.txt | grep -c "^V")
-			if [[ "$NUMBEROFCLIENTS" = '0' ]]; then
+			if [ "$NUMBEROFCLIENTS" = 0 ]
+      then
 				echo ""
 				echo "You have no existing clients!"
 				exit 5
@@ -100,8 +103,8 @@ if [[ -e /etc/openvpn/server.conf ]]; then
 			echo ""
 			echo "Select the existing client certificate you want to revoke"
 			tail -n +2 /etc/openvpn/easy-rsa/pki/index.txt | grep "^V" | cut -d '=' -f 2 | nl -s ') '
-			if [[ "$NUMBEROFCLIENTS" = '1' ]]; then
-				read -p "Select one client [1]: " CLIENTNUMBER
+			if [ "$NUMBEROFCLIENTS" = 1 ]
+        then read -p "Select one client [1]: " CLIENTNUMBER
 			else
 				read -p "Select one client [1-$NUMBEROFCLIENTS]: " CLIENTNUMBER
 			fi
@@ -110,39 +113,37 @@ if [[ -e /etc/openvpn/server.conf ]]; then
 			./easyrsa --batch revoke $CLIENT
 			./easyrsa gen-crl
 			# And restart
-			if pgrep systemd-journal; then
-				systemctl restart openvpn@server.service
-			else
-				if [[ "$OS" = 'debian' ]]; then
-					/etc/init.d/openvpn restart
-				else
-					service openvpn restart
-				fi
+			if pgrep systemd-journal
+        then systemctl restart openvpn@server.service
+			elif [ $OS = debian ]
+        then /etc/init.d/openvpn restart
+      else
+        service openvpn restart
 			fi
 			echo ""
 			echo "Certificate for client $CLIENT revoked"
-			exit
-			;;
-			3) 
+			exit;;
+			3)
 			echo ""
-			read -p "Do you really want to remove OpenVPN? [y/n]: " -e -i n REMOVE
-			if [[ "$REMOVE" = 'y' ]]; then
-				PORT=$(grep '^port ' /etc/openvpn/server.conf | cut -d " " -f 2)
-				if pgrep firewalld; then
-					# Using both permanent and not permanent rules to avoid a firewalld reload.
+      read -p "Do you really want to remove OpenVPN? [N/y]: " REMOVE
+			if [ $REMOVE = y ]
+        then PORT=$(grep '^port ' /etc/openvpn/server.conf | cut -d " " -f 2)
+				if pgrep firewalld
+				then # Using both permanent and not permanent rules to avoid a firewalld reload.
 					firewall-cmd --zone=public --remove-port=$PORT/udp
 					firewall-cmd --zone=trusted --remove-source=10.8.0.0/24
 					firewall-cmd --permanent --zone=public --remove-port=$PORT/udp
 					firewall-cmd --permanent --zone=trusted --remove-source=10.8.0.0/24
 				fi
-				if iptables -L | grep -qE 'REJECT|DROP'; then
+				if iptables -L | grep -qE 'REJECT|DROP'
+				then
 					sed -i "/iptables -I INPUT -p udp --dport $PORT -j ACCEPT/d" $RCLOCAL
 					sed -i "/iptables -I FORWARD -s 10.8.0.0\/24 -j ACCEPT/d" $RCLOCAL
 					sed -i "/iptables -I FORWARD -m state --state RELATED,ESTABLISHED -j ACCEPT/d" $RCLOCAL
 				fi
 				sed -i '/iptables -t nat -A POSTROUTING -s 10.8.0.0\/24 -j SNAT --to /d' $RCLOCAL
-				if [[ "$OS" = 'debian' ]]; then
-					apt-get remove --purge -y openvpn openvpn-blacklist
+				if [ $OS = debian ]
+          then apt-get remove --purge -y openvpn openvpn-blacklist
 				else
 					yum remove openvpn -y
 				fi
@@ -154,8 +155,7 @@ if [[ -e /etc/openvpn/server.conf ]]; then
 				echo ""
 				echo "Removal aborted!"
 			fi
-			exit
-			;;
+			exit;;
 			4) exit;;
 		esac
 	done
@@ -169,10 +169,12 @@ else
 	echo ""
 	echo "First I need to know the IPv4 address of the network interface you want OpenVPN"
 	echo "listening to."
-	read -p "IP address: " -e -i $IP IP
+  read -p "IP address: $IP " IP
+  IP=${IP:-$IP}
 	echo ""
 	echo "What port do you want for OpenVPN?"
-	read -p "Port: " -e -i 1194 PORT
+	read -p "Port: 1194 " PORT
+  PORT=${PORT:-1194}
 	echo ""
 	echo "What DNS do you want to use with the VPN?"
 	echo "   1) Current system resolvers"
@@ -181,15 +183,19 @@ else
 	echo "   4) NTT"
 	echo "   5) Hurricane Electric"
 	echo "   6) Google"
-	read -p "DNS [1-6]: " -e -i 1 DNS
+	read -p "DNS [1-6]: 1 " DNS
+  DNS=${DNS:-1}
 	echo ""
 	echo "Finally, tell me your name for the client cert"
 	echo "Please, use one word only, no special characters"
-	read -p "Client name: " -e -i client CLIENT
-	echo ""
+  read -p "Client name: client " CLIENT
+  CLIENT=${CLIENT:-client}
+  echo ""
 	echo "Okay, that was all I needed. We are ready to setup your OpenVPN server now"
-	read -n1 -r -p "Press any key to continue..."
-		if [[ "$OS" = 'debian' ]]; then
+	echo "Press [ENTER] to continue... \c"
+  read
+  if [ $OS = debian ]
+  then
 		apt-get update
 		apt-get install openvpn iptables openssl ca-certificates -y
 	else
@@ -198,8 +204,8 @@ else
 		yum install openvpn iptables openssl wget ca-certificates -y
 	fi
 	# An old version of easy-rsa was available by default in some openvpn packages
-	if [[ -d /etc/openvpn/easy-rsa/ ]]; then
-		rm -rf /etc/openvpn/easy-rsa/
+	if [ -d /etc/openvpn/easy-rsa/ ]
+    then rm -rf /etc/openvpn/easy-rsa/
 	fi
 	# Get easy-rsa
 	wget -O ~/EasyRSA-3.0.1.tgz https://github.com/OpenVPN/easy-rsa/releases/download/3.0.1/EasyRSA-3.0.1.tgz
@@ -234,31 +240,26 @@ ifconfig-pool-persist ipp.txt" > /etc/openvpn/server.conf
 	echo 'push "redirect-gateway def1 bypass-dhcp"' >> /etc/openvpn/server.conf
 	# DNS
 	case $DNS in
-		1) 
+		1)
 		# Obtain the resolvers from resolv.conf and use them for OpenVPN
-		grep -v '#' /etc/resolv.conf | grep 'nameserver' | grep -E -o '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}' | while read line; do
+		grep -v '#' /etc/resolv.conf | grep 'nameserver' | grep -E -o '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}' | while read line
+		do
 			echo "push \"dhcp-option DNS $line\"" >> /etc/openvpn/server.conf
-		done
-		;;
+		done;;
 		2)
 		echo 'push "dhcp-option DNS 208.67.222.222"' >> /etc/openvpn/server.conf
-		echo 'push "dhcp-option DNS 208.67.220.220"' >> /etc/openvpn/server.conf
-		;;
-		3) 
+		echo 'push "dhcp-option DNS 208.67.220.220"' >> /etc/openvpn/server.conf;;
+		3)
 		echo 'push "dhcp-option DNS 4.2.2.2"' >> /etc/openvpn/server.conf
-		echo 'push "dhcp-option DNS 4.2.2.4"' >> /etc/openvpn/server.conf
-		;;
-		4) 
+		echo 'push "dhcp-option DNS 4.2.2.4"' >> /etc/openvpn/server.conf;;
+		4)
 		echo 'push "dhcp-option DNS 129.250.35.250"' >> /etc/openvpn/server.conf
-		echo 'push "dhcp-option DNS 129.250.35.251"' >> /etc/openvpn/server.conf
-		;;
-		5) 
-		echo 'push "dhcp-option DNS 74.82.42.42"' >> /etc/openvpn/server.conf
-		;;
-		6) 
+		echo 'push "dhcp-option DNS 129.250.35.251"' >> /etc/openvpn/server.conf;;
+		5)
+		echo 'push "dhcp-option DNS 74.82.42.42"' >> /etc/openvpn/server.conf;;
+		6)
 		echo 'push "dhcp-option DNS 8.8.8.8"' >> /etc/openvpn/server.conf
-		echo 'push "dhcp-option DNS 8.8.4.4"' >> /etc/openvpn/server.conf
-		;;
+		echo 'push "dhcp-option DNS 8.8.4.4"' >> /etc/openvpn/server.conf;;
 	esac
 	echo "keepalive 10 120
 comp-lzo
@@ -268,14 +269,14 @@ status openvpn-status.log
 verb 3
 crl-verify /etc/openvpn/easy-rsa/pki/crl.pem" >> /etc/openvpn/server.conf
 	# Enable net.ipv4.ip_forward for the system
-	if [[ "$OS" = 'debian' ]]; then
-		sed -i 's|#net.ipv4.ip_forward=1|net.ipv4.ip_forward=1|' /etc/sysctl.conf
+	if [ $OS = debian ]
+		then sed -i 's|#net.ipv4.ip_forward=1|net.ipv4.ip_forward=1|' /etc/sysctl.conf
 	else
 		# CentOS 5 and 6
 		sed -i 's|net.ipv4.ip_forward = 0|net.ipv4.ip_forward = 1|' /etc/sysctl.conf
 		# CentOS 7
-		if ! grep -q "net.ipv4.ip_forward=1" "/etc/sysctl.conf"; then
-			echo 'net.ipv4.ip_forward=1' >> /etc/sysctl.conf
+		if ! grep -q "net.ipv4.ip_forward=1" "/etc/sysctl.conf"
+			then echo 'net.ipv4.ip_forward=1' >> /etc/sysctl.conf
 		fi
 	fi
 	# Avoid an unneeded reboot
@@ -283,7 +284,8 @@ crl-verify /etc/openvpn/easy-rsa/pki/crl.pem" >> /etc/openvpn/server.conf
 	# Set NAT for the VPN subnet
 	iptables -t nat -A POSTROUTING -s 10.8.0.0/24 -j SNAT --to $IP
 	sed -i "1 a\iptables -t nat -A POSTROUTING -s 10.8.0.0/24 -j SNAT --to $IP" $RCLOCAL
-	if pgrep firewalld; then
+	if pgrep firewalld
+	then
 		# We don't use --add-service=openvpn because that would only work with
 		# the default port. Using both permanent and not permanent rules to
 		# avoid a firewalld reload.
@@ -292,7 +294,8 @@ crl-verify /etc/openvpn/easy-rsa/pki/crl.pem" >> /etc/openvpn/server.conf
 		firewall-cmd --permanent --zone=public --add-port=$PORT/udp
 		firewall-cmd --permanent --zone=trusted --add-source=10.8.0.0/24
 	fi
-	if iptables -L | grep -qE 'REJECT|DROP'; then
+	if iptables -L | grep -qE 'REJECT|DROP'
+	then
 		# If iptables has at least one REJECT rule, we asume this is needed.
 		# Not the best approach but I can't think of other and this shouldn't
 		# cause problems.
@@ -304,33 +307,28 @@ crl-verify /etc/openvpn/easy-rsa/pki/crl.pem" >> /etc/openvpn/server.conf
 		sed -i "1 a\iptables -I FORWARD -m state --state RELATED,ESTABLISHED -j ACCEPT" $RCLOCAL
 	fi
 	# And finally, restart OpenVPN
-	if [[ "$OS" = 'debian' ]]; then
-		# Little hack to check for systemd
-		if pgrep systemd-journal; then
-			systemctl restart openvpn@server.service
-		else
-			/etc/init.d/openvpn restart
-		fi
+	if pgrep systemd-journal
+  then # Little hack to check for systemd
+    systemctl restart openvpn@server.service
+    systemctl enable openvpn@server.service
+  elif [ $OS = debian ]
+  	then /etc/init.d/openvpn restart
 	else
-		if pgrep systemd-journal; then
-			systemctl restart openvpn@server.service
-			systemctl enable openvpn@server.service
-		else
-			service openvpn restart
-			chkconfig openvpn on
-		fi
+    service openvpn restart
+    chkconfig openvpn on
 	fi
 	# Try to detect a NATed connection and ask about it to potential LowEndSpirit users
 	EXTERNALIP=$(wget -qO- ipv4.icanhazip.com)
-	if [[ "$IP" != "$EXTERNALIP" ]]; then
+	if [ $IP != "$EXTERNALIP" ]
+	then
 		echo ""
 		echo "Looks like your server is behind a NAT!"
 		echo ""
 		echo "If your server is NATed (LowEndSpirit), I need to know the external IP"
 		echo "If that's not the case, just ignore this and leave the next field blank"
-		read -p "External IP: " -e USEREXTERNALIP
-		if [[ "$USEREXTERNALIP" != "" ]]; then
-			IP=$USEREXTERNALIP
+		read -p "External IP: " USEREXTERNALIP
+		if [ "$USEREXTERNALIP" != "" ]
+      then echo IP=$USEREXTERNALIP
 		fi
 	fi
 	# client-common.txt is created so we have a template to add further users later


### PR DESCRIPTION
The script is now POSIX-compliant and therefore more universal across the UNIX systems. It's bash independent, and should work on sh, dash, bash, ksh, zsh.

An init system detection was also added for sytstemd and sysvinit.

I have tested it with dash. It looks to work, but advanced testing is still needed.