### PR TITLE
NAT: explicitly mention FQDN besides IP

### DIFF
--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -345,9 +345,9 @@ crl-verify crl.pem" >> /etc/openvpn/server.conf
 		echo ""
 		echo "Looks like your server is behind a NAT!"
 		echo ""
-		echo "If your server is NATed (LowEndSpirit), I need to know the external IP"
+		echo "If your server is NATed (i.e. LowEndSpirit), I need to know the external IP or FQDN"
 		echo "If that's not the case, just ignore this and leave the next field blank"
-		read -p "External IP: " -e USEREXTERNALIP
+		read -p "External IP or FQDN: " -e USEREXTERNALIP
 		if [[ "$USEREXTERNALIP" != "" ]]; then
 			IP=$USEREXTERNALIP
 		fi


### PR DESCRIPTION
Specifying a fully quialified domain name also works
as input, so it can be mentioned to the user.

Also fixed the nitpick of preceding "i.e." before
LowEndSpirit, just in case the user doesn't know the
service at all.