### PR TITLE
Store configuration in ~/vpn instead of ~

### DIFF
--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -42,11 +42,11 @@ fi
 # Also using a variable for possible future adaptation and customization
 
 #baseFolder="~/vpn"
-baseFolder="/home/$(whoami)/vpn"
+baseFolder="$HOME/vpn"
 
 newclient () {
 	#baseFolder="~/vpn"
-	baseFolder="/home/$(whoami)/vpn"	
+	baseFolder="$HOME/vpn"	
 	
 	mkdir $baseFolder -p
 	

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -38,18 +38,25 @@ else
 	exit 4
 fi
 
+# Makes the VPN folder in home, to keep things neater
+# Also using a variable for possible future adaptation and customization
+set baseFolder="~/vpn"
+
 newclient () {
+	
+	mkdir $baseFolder -p
+	
 	# Generates the custom client.ovpn
-	cp /etc/openvpn/client-common.txt ~/$1.ovpn
-	echo "<ca>" >> ~/$1.ovpn
-	cat /etc/openvpn/easy-rsa/pki/ca.crt >> ~/$1.ovpn
-	echo "</ca>" >> ~/$1.ovpn
-	echo "<cert>" >> ~/$1.ovpn
-	cat /etc/openvpn/easy-rsa/pki/issued/$1.crt >> ~/$1.ovpn
-	echo "</cert>" >> ~/$1.ovpn
-	echo "<key>" >> ~/$1.ovpn
-	cat /etc/openvpn/easy-rsa/pki/private/$1.key >> ~/$1.ovpn
-	echo "</key>" >> ~/$1.ovpn
+	cp /etc/openvpn/client-common.txt $baseFolder/$1.ovpn
+	echo "<ca>" >> $baseFolder/$1.ovpn
+	cat /etc/openvpn/easy-rsa/pki/ca.crt >> $baseFolder/$1.ovpn
+	echo "</ca>" >> $baseFolder/$1.ovpn
+	echo "<cert>" >> $baseFolder/$1.ovpn
+	cat /etc/openvpn/easy-rsa/pki/issued/$1.crt >> $baseFolder/$1.ovpn
+	echo "</cert>" >> $baseFolder/$1.ovpn
+	echo "<key>" >> $baseFolder/$1.ovpn
+	cat /etc/openvpn/easy-rsa/pki/private/$1.key >> $baseFolder/$1.ovpn
+	echo "</key>" >> $baseFolder/$1.ovpn
 }
 
 
@@ -85,7 +92,7 @@ if [[ -e /etc/openvpn/server.conf ]]; then
 			# Generates the custom client.ovpn
 			newclient "$CLIENT"
 			echo ""
-			echo "Client $CLIENT added, certs available at ~/$CLIENT.ovpn"
+			echo "Client $CLIENT added, certs available at $baseFolder/$CLIENT.ovpn"
 			exit
 			;;
 			2)
@@ -366,6 +373,6 @@ verb 3" > /etc/openvpn/client-common.txt
 	echo ""
 	echo "Finished!"
 	echo ""
-	echo "Your client config is available at ~/$CLIENT.ovpn"
+	echo "Your client config is available at $baseFolder/$CLIENT.ovpn"
 	echo "If you want to add more clients, you simply need to run this script another time!"
 fi

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -49,16 +49,17 @@ newclient () {
 	mkdir $baseFolder -p
 	
 	# Generates the custom client.ovpn
-	cp /etc/openvpn/client-common.txt $baseFolder/$1.ovpn
-	echo "<ca>" >> $baseFolder/$1.ovpn
-	cat /etc/openvpn/easy-rsa/pki/ca.crt >> $baseFolder/$1.ovpn
-	echo "</ca>" >> $baseFolder/$1.ovpn
-	echo "<cert>" >> $baseFolder/$1.ovpn
-	cat /etc/openvpn/easy-rsa/pki/issued/$1.crt >> $baseFolder/$1.ovpn
-	echo "</cert>" >> $baseFolder/$1.ovpn
-	echo "<key>" >> $baseFolder/$1.ovpn
-	cat /etc/openvpn/easy-rsa/pki/private/$1.key >> $baseFolder/$1.ovpn
-	echo "</key>" >> $baseFolder/$1.ovpn
+	touch "$baseFolder/$1.ovpn"
+	cp /etc/openvpn/client-common.txt "$baseFolder/$1.ovpn"
+	echo "<ca>" >> "$baseFolder/$1.ovpn"
+	cat /etc/openvpn/easy-rsa/pki/ca.crt >> "$baseFolder/$1.ovpn"
+	echo "</ca>" >> "$baseFolder/$1.ovpn"
+	echo "<cert>" >> "$baseFolder/$1.ovpn"
+	cat /etc/openvpn/easy-rsa/pki/issued/$1.crt >> "$baseFolder/$1.ovpn"
+	echo "</cert>" >> "$baseFolder/$1.ovpn"
+	echo "<key>" >> "$baseFolder/$1.ovpn"
+	cat /etc/openvpn/easy-rsa/pki/private/$1.key >> "$baseFolder/$1.ovpn"
+	echo "</key>" >> "$baseFolder/$1.ovpn"
 }
 
 

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -40,9 +40,11 @@ fi
 
 # Makes the VPN folder in home, to keep things neater
 # Also using a variable for possible future adaptation and customization
-set baseFolder="~/vpn"
+
+baseFolder="~/vpn"
 
 newclient () {
+	baseFolder="~/vpn"
 	
 	mkdir $baseFolder -p
 	

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -41,12 +41,11 @@ fi
 # Makes the VPN folder in home, to keep things neater
 # Also using a variable for possible future adaptation and customization
 
-#baseFolder="~/vpn"
 baseFolder="$HOME/vpn"
 
 newclient () {
-	#baseFolder="~/vpn"
-	baseFolder="$HOME/vpn"	
+
+#	baseFolder="$HOME/vpn"	
 	
 	mkdir $baseFolder -p
 	

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -41,10 +41,12 @@ fi
 # Makes the VPN folder in home, to keep things neater
 # Also using a variable for possible future adaptation and customization
 
-baseFolder="~/vpn"
+#baseFolder="~/vpn"
+baseFolder="/home/$(whoami)/vpn"
 
 newclient () {
-	baseFolder="~/vpn"
+	#baseFolder="~/vpn"
+	baseFolder="/home/$(whoami)/vpn"	
 	
 	mkdir $baseFolder -p
 	


### PR DESCRIPTION
Since the home directory can get messy as you add multiple client files, I lightly modified the script to store the client config info in ~/vpn. 

Also, that path is in a variable, so it is easy to change at a later date, or even the possible implementation of a user-selectable output directory in the future.