### PR TITLE
Added a check before revoke

### DIFF
--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -111,7 +111,7 @@ if [[ -e /etc/openvpn/server.conf ]]; then
 			else
 				read -p "Select one client [1-$NUMBEROFCLIENTS]: " CLIENTNUMBER
 			fi
-			if [[ "$CLIENTNUMBER" -ge 1 -a "$CLIENTNUMBER" -le $NUMBEROFCLIENTS ]]; then
+			if [[ "$CLIENTNUMBER" =~ ^[0-9]+$ ]] && [[ "$CLIENTNUMBER" -ge 1 ]] && [[ "$CLIENTNUMBER" -le $NUMBEROFCLIENTS ]]; then
 				CLIENT=$(tail -n +2 /etc/openvpn/easy-rsa/pki/index.txt | grep "^V" | cut -d '=' -f 2 | sed -n "$CLIENTNUMBER"p)
 				cd /etc/openvpn/easy-rsa/
 				./easyrsa --batch revoke $CLIENT

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -127,7 +127,7 @@ if [[ -e /etc/openvpn/server.conf ]]; then
 				echo "Certificate for client $CLIENT revoked"
 			else
 				echo ""
-				echo "You selected a invalid client!"
+				echo "You selected an invalid client!"
 				exit 7
 			fi
 			exit

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -111,19 +111,25 @@ if [[ -e /etc/openvpn/server.conf ]]; then
 			else
 				read -p "Select one client [1-$NUMBEROFCLIENTS]: " CLIENTNUMBER
 			fi
-			CLIENT=$(tail -n +2 /etc/openvpn/easy-rsa/pki/index.txt | grep "^V" | cut -d '=' -f 2 | sed -n "$CLIENTNUMBER"p)
-			cd /etc/openvpn/easy-rsa/
-			./easyrsa --batch revoke $CLIENT
-			./easyrsa gen-crl
-			rm -rf pki/reqs/$CLIENT.req
-			rm -rf pki/private/$CLIENT.key
-			rm -rf pki/issued/$CLIENT.crt
-			rm -rf /etc/openvpn/crl.pem
-			cp /etc/openvpn/easy-rsa/pki/crl.pem /etc/openvpn/crl.pem
-			# CRL is read with each client connection, when OpenVPN is dropped to nobody
-			chown nobody:$GROUPNAME /etc/openvpn/crl.pem
-			echo ""
-			echo "Certificate for client $CLIENT revoked"
+			if [[ "$CLIENTNUMBER" -ge 1 -a "$CLIENTNUMBER" -le $NUMBEROFCLIENTS ]]; then
+				CLIENT=$(tail -n +2 /etc/openvpn/easy-rsa/pki/index.txt | grep "^V" | cut -d '=' -f 2 | sed -n "$CLIENTNUMBER"p)
+				cd /etc/openvpn/easy-rsa/
+				./easyrsa --batch revoke $CLIENT
+				./easyrsa gen-crl
+				rm -rf pki/reqs/$CLIENT.req
+				rm -rf pki/private/$CLIENT.key
+				rm -rf pki/issued/$CLIENT.crt
+				rm -rf /etc/openvpn/crl.pem
+				cp /etc/openvpn/easy-rsa/pki/crl.pem /etc/openvpn/crl.pem
+				# CRL is read with each client connection, when OpenVPN is dropped to nobody
+				chown nobody:$GROUPNAME /etc/openvpn/crl.pem
+				echo ""
+				echo "Certificate for client $CLIENT revoked"
+			else
+				echo ""
+				echo "You selected a invalid client!"
+				exit 7
+			fi
 			exit
 			;;
 			3) 


### PR DESCRIPTION
When revoking a client certificate, there is no bound check, which result in errors.

Added a check if the value entered is an integer and between the allowed range.