### PR TITLE
added or to line 36 to fix aws linux ami setup

### DIFF
--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -33,7 +33,7 @@ if [[ -e /etc/debian_version ]]; then
 	OS=debian
 	GROUPNAME=nogroup
 	RCLOCAL='/etc/rc.local'
-elif [[ -e /etc/centos-release || -e /etc/redhat-release ]]; then
+elif [[ -e /etc/centos-release || -e /etc/redhat-release || /etc/system-release ]]; then
 	OS=centos
 	GROUPNAME=nobody
 	RCLOCAL='/etc/rc.d/rc.local'


### PR DESCRIPTION
Amazon Linux AMI is close enough to CentOS to work fine as long as we add /etc/system-release to the if block.