### PR TITLE
Allow multiple connections using one certificate

### DIFF
--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -267,6 +267,7 @@ auth SHA512
 tls-auth ta.key 0
 topology subnet
 server 10.8.0.0 255.255.255.0
+duplicate-cn
 ifconfig-pool-persist ipp.txt" > /etc/openvpn/server.conf
 	echo 'push "redirect-gateway def1 bypass-dhcp"' >> /etc/openvpn/server.conf
 	# DNS


### PR DESCRIPTION
Could be confusing to anyone using this script otherwise.

Source:
https://www.unixtutorial.org/2016/03/multiple-openvpn-clients-sharing-the-same-certificate/