### PR TITLE
Add bogus ipv6 address to block IPV6 access

### DIFF
--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -389,6 +389,8 @@ auth SHA512
 cipher AES-256-CBC
 comp-lzo
 setenv opt block-outside-dns
+ifconfig-ipv6 fd69:2205:1941:1::1/64 fd69:2205:1941:1::2
+redirect-gateway ipv6
 key-direction 1
 verb 3" > /etc/openvpn/client-common.txt
 	# Generates the custom client.ovpn


### PR DESCRIPTION
Added a bogus ipv6 address to block ipv6 from connecting while using the vpn on ipv6 enabled networks.