### PR TITLE
Enable user to set passphrase to config file

### DIFF
--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -72,8 +72,8 @@ if [[ -e /etc/openvpn/server.conf ]]; then
 			read -p "Client name: " -e CLIENT
 			cd /etc/openvpn/easy-rsa/
 			./easyrsa build-client-full $CLIENT nopass\
-			# Ask to set a password for the configuration file
-			read -p "Do you want to set a passprashe for the configuration? [y/N]: " -e -i N SETPASS
+			# Ask to set a passphrase for the configuration file
+			read -p "Do you want to set a passphrase for the configuration file? [y/N]: " -e -i N SETPASS
 			if [[ "$SETPASS" = 'y' || "$SETPASS" = 'Y' ]]; then
 				./easyrsa set-rsa-pass $CLIENT
 			fi

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -71,7 +71,12 @@ if [[ -e /etc/openvpn/server.conf ]]; then
 			echo "Please, use one word only, no special characters."
 			read -p "Client name: " -e CLIENT
 			cd /etc/openvpn/easy-rsa/
-			./easyrsa build-client-full $CLIENT nopass
+			./easyrsa build-client-full $CLIENT nopass\
+			# Ask to set a password for the configuration file
+			read -p "Do you want to set a passprashe for the configuration? [y/N]: " -e -i N SETPASS
+			if [[ "$SETPASS" = 'y' || "$SETPASS" = 'Y' ]]; then
+				./easyrsa set-rsa-pass $CLIENT
+			fi
 			# Generates the custom client.ovpn
 			newclient "$CLIENT"
 			echo

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -71,7 +71,7 @@ if [[ -e /etc/openvpn/server.conf ]]; then
 			echo "Please, use one word only, no special characters."
 			read -p "Client name: " -e CLIENT
 			cd /etc/openvpn/easy-rsa/
-			./easyrsa build-client-full $CLIENT nopass\
+			./easyrsa build-client-full $CLIENT nopass
 			# Ask to set a passphrase for the configuration file
 			read -p "Do you want to set a passphrase for the configuration file? [y/N]: " -e -i N SETPASS
 			if [[ "$SETPASS" = 'y' || "$SETPASS" = 'Y' ]]; then


### PR DESCRIPTION
Enabling the user to set a passphrase to a config file adds an extra layer of security in case access to the client machine or config file is obtained by an unauthorized party. Default is set "no" so introduces minimal impact on set up.