### PR TITLE
add float option so that clients can roam across different addresses

### DIFF
--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -266,6 +266,7 @@ key server.key
 dh dh.pem
 auth SHA512
 tls-auth ta.key 0
+float
 topology subnet
 server 10.8.0.0 255.255.255.0
 ifconfig-pool-persist ipp.txt" > /etc/openvpn/server.conf


### PR DESCRIPTION
I tried this on my own server and it is especially great for phones that roam between different wifi connections and cell networks.  It immediately reconnects to the vpn when the address of the client changes instead of waiting 2 minutes and timing out and then re-authenticating.  I can't think of a downside.  I've seen that it's supported in at least 2.3.6 and around 2013 by looking around on the internet but is probably supported even before that.