### PR TITLE
Swap order of auth SHA512 and cipher AES-256-CBC

### DIFF
--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -390,8 +390,8 @@ nobind
 persist-key
 persist-tun
 remote-cert-tls server
-auth SHA512
 cipher AES-256-CBC
+auth SHA512
 setenv opt block-outside-dns
 key-direction 1
 verb 3" > /etc/openvpn/client-common.txt


### PR DESCRIPTION
I'm no expert but according to https://www.digitalocean.com/community/questions/help-with-the-following-error-tls-error-cannot-locate-hmac-in-incoming-packet-from-af_inet swapping these lines in client.conf fixes an error in the log