### PR TITLE
Add auth-nocache option

### DIFF
--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -394,6 +394,7 @@ auth SHA512
 cipher AES-256-CBC
 setenv opt block-outside-dns
 key-direction 1
+auth-nocache
 verb 3" > /etc/openvpn/client-common.txt
 	# Generates the custom client.ovpn
 	newclient "$CLIENT"


### PR DESCRIPTION
To prevent the "WARNING: this configuration may cache passwords in memory -- use the auth-nocache option to prevent this" warning.