### PR TITLE
Put ipp.txt and status.log in /var/run and /var/log respectively

### DIFF
--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -337,7 +337,7 @@ auth SHA512
 tls-crypt tc.key
 topology subnet
 server 10.8.0.0 255.255.255.0
-ifconfig-pool-persist ipp.txt" > /etc/openvpn/server/server.conf
+ifconfig-pool-persist /var/run/openvpn/ipp.txt" > /etc/openvpn/server/server.conf
 	echo 'push "redirect-gateway def1 bypass-dhcp"' >> /etc/openvpn/server/server.conf
 	# DNS
 	case "$dns" in
@@ -377,7 +377,7 @@ user nobody
 group $group_name
 persist-key
 persist-tun
-status openvpn-status.log
+status /var/log/openvpn-status.log
 verb 3
 crl-verify crl.pem" >> /etc/openvpn/server/server.conf
 	if [[ "$protocol" = "udp" ]]; then


### PR DESCRIPTION
In my use case, I wish to place `/etc/openvpn` in a read-only filesystem
so I can prevent corruption from unexpected power cycle.

`/var/run` and `/var/log` should be pretty standard on Linux systems,
though I didn't verify it beyond Debian-based OSes.