### PR TITLE
Removing 3rd line in openssl-easyrsa.cnf stops error causing heartache and issues on GH.

### DIFF
--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -305,6 +305,7 @@ LimitNPROC=infinity" > /etc/systemd/system/openvpn-server@server.service.d/disab
 	cd /etc/openvpn/server/easy-rsa/
 	# Create the PKI, set up the CA and the server and client certificates
 	./easyrsa init-pki
+	sed -i '3d' openssl-easyrsa.cnf
 	./easyrsa --batch build-ca nopass
 	EASYRSA_CERT_EXPIRE=3650 ./easyrsa build-server-full server nopass
 	EASYRSA_CERT_EXPIRE=3650 ./easyrsa build-client-full "$client" nopass


### PR DESCRIPTION
I saw this, and without seeing your gentle reassurances it's NBD, was a tad worried.  Telling sed to drop the line was suggested by ecrist at OpenVPN [here](https://github.com/OpenVPN/easy-rsa/issues/261).  It was supposed to be fixed in 3.0.6, but they missed it, should be in the forthcoming release.

Otherwise, thank you very much for this tool.  You saved me hours of work!