### PR TITLE
Use openvpn status path from systemd service

### DIFF
--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -310,7 +310,6 @@ user nobody
 group $group_name
 persist-key
 persist-tun
-status openvpn-status.log
 verb 3
 crl-verify crl.pem" >> /etc/openvpn/server/server.conf
 	if [[ "$protocol" = "udp" ]]; then


### PR DESCRIPTION
The new systemd service at `/usr/lib/systemd/system/openvpn-server@.service` that comes with openvpn 2.4 includes the status option in `ExecStart=/usr/sbin/openvpn --status %t/openvpn-server/status-%i.log --status-version 2 --suppress-timestamps --config %i.conf`

Using this default allows to have multiple servers with their own status files and all in the same log directory. Example `/run/openvpn-server/status-server.log` `/run/openvpn-server/status-server2.log`