### PR TITLE
Prevent Broken SSH after Client Connected

### DIFF
--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -417,6 +417,7 @@ persist-tun
 remote-cert-tls server
 auth SHA512
 cipher AES-256-CBC
+route-nopull
 ignore-unknown-option block-outside-dns
 block-outside-dns
 verb 3" > /etc/openvpn/server/client-common.txt


### PR DESCRIPTION
This update proposal is about the client .opvn file. In the client side, if the person ssh to a remote server (like AWS EC2 Instance) and run OpenVPN Client Connect command "openvpn client.ovpn" then the current and future SSH Connection between that person's laptop and the remote server will be broken and the vpn-connected server is inaccessable unless reboot. 

This option prevents that SSH broken connection from happening after a successful vpn connection and static routes can be added later by the client side.