### PR TITLE
Moving output directory of client config.

### DIFF
--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -80,6 +80,7 @@ TUN needs to be enabled before running this installer."
 fi
 
 new_client () {
+	mkdir -p /etc/openvpn/client
 	# Generates the custom client.ovpn
 	{
 	cat /etc/openvpn/server/client-common.txt
@@ -95,7 +96,7 @@ new_client () {
 	echo "<tls-crypt>"
 	sed -ne '/BEGIN OpenVPN Static key/,$ p' /etc/openvpn/server/tc.key
 	echo "</tls-crypt>"
-	} > ~/"$client".ovpn
+	} > /etc/openvpn/client/"$client".ovpn
 }
 
 if [[ ! -e /etc/openvpn/server/server.conf ]]; then
@@ -426,7 +427,7 @@ verb 3" > /etc/openvpn/server/client-common.txt
 	echo
 	echo "Finished!"
 	echo
-	echo "The client configuration is available in:" ~/"$client.ovpn"
+	echo "The client configuration is available in:" /etc/openvpn/client/"$client".ovpn
 	echo "New clients can be added by running this script again."
 else
 	clear
@@ -458,7 +459,7 @@ else
 			# Generates the custom client.ovpn
 			new_client
 			echo
-			echo "$client added. Configuration available in:" ~/"$client.ovpn"
+			echo "$client added. Configuration available in:" /etc/openvpn/client/"$client".ovpn
 			exit
 		;;
 		2)


### PR DESCRIPTION
Moving directory output of client configuration from `/root` to `/etc/openvpn/client`.