### PR TITLE
Use --genkey secret filename instead

### DIFF
--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -254,7 +254,7 @@ LimitNPROC=infinity" > /etc/systemd/system/openvpn-server@server.service.d/disab
 	# Without +x in the directory, OpenVPN can't run a stat() on the CRL file
 	chmod o+x /etc/openvpn/server/
 	# Generate key for tls-crypt
-	openvpn --genkey --secret /etc/openvpn/server/tc.key
+	openvpn --genkey secret /etc/openvpn/server/tc.key
 	# Create the DH parameters file using the predefined ffdhe2048 group
 	echo '-----BEGIN DH PARAMETERS-----
 MIIBCAKCAQEA//////////+t+FRYortKmq/cViAnPTzx2LnFg84tNpWp4TZBFGQz


### PR DESCRIPTION
Fix for:
WARNING: Using --genkey --secret filename is DEPRECATED.  Use --genkey secret filename instead.

https://community.openvpn.net/openvpn/wiki/DeprecatedOptions#Option:--secret

Status 	Removed
Deprecated in: 	OpenVPN v2.4
Removed in: 	OpenVPN v2.5
Affects: 	--genkey
Result if used: 	User Warning printed
Replaced by: 	secret (No leading double dash)
Examples: 	Use --genkey secret filename
Notes: