### PR TITLE
change deprecated option cipher to data-ciphers

### DIFF
--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -323,7 +323,7 @@ server 10.8.0.0 255.255.255.0" > /etc/openvpn/server/server.conf
 	esac
 	echo 'push "block-outside-dns"' >> /etc/openvpn/server/server.conf
 	echo "keepalive 10 120
-cipher AES-256-CBC
+data-ciphers AES-256-GCM
 user nobody
 group $group_name
 persist-key
@@ -423,7 +423,7 @@ persist-key
 persist-tun
 remote-cert-tls server
 auth SHA512
-cipher AES-256-CBC
+data-ciphers AES-256-GCM
 ignore-unknown-option block-outside-dns
 verb 3" > /etc/openvpn/server/client-common.txt
 	# Enable and start the OpenVPN service


### PR DESCRIPTION
fix this waring

```
DEPRECATED OPTION: --cipher set to ‘AES-256-CBC’ but missing in --data-ciphers (AES-256-GCM:AES-128-GCM). Future OpenVPN version will ignore --cipher for cipher negotiations. Add ‘AES-256-CBC’ to --data-ciphers or change --cipher ‘AES-256-CBC’ to --data-ciphers-fallback ‘AES-256-CBC’ to silence this warning.
```
and change default data cipher to OpenVPN recommended cipher 