### PR TITLE
Changed --genkey --secret to --genkey secret

### DIFF
--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -260,7 +260,7 @@ LimitNPROC=infinity" > /etc/systemd/system/openvpn-server@server.service.d/disab
 	# Without +x in the directory, OpenVPN can't run a stat() on the CRL file
 	chmod o+x /etc/openvpn/server/
 	# Generate key for tls-crypt
-	openvpn --genkey --secret /etc/openvpn/server/tc.key
+	openvpn --genkey secret /etc/openvpn/server/tc.key
 	# Create the DH parameters file using the predefined ffdhe2048 group
 	echo '-----BEGIN DH PARAMETERS-----
 MIIBCAKCAQEA//////////+t+FRYortKmq/cViAnPTzx2LnFg84tNpWp4TZBFGQz


### PR DESCRIPTION
DEPRECATED OPTION: The option --secret is deprecated.
WARNING: Using --genkey --secret filename is DEPRECATED.  Use --genkey secret filename instead.