### PR TITLE
Fixing issues that happens when public or private IPv4 changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,5 +16,7 @@ Once it ends, you can run it again to add more users, remove some of them or eve
 You can get a VPS from just 2€/month at [AlphaVPS](https://alphavps.com/clients/aff.php?aff=474&pid=422).
 
 ### Donations
-
 If you want to show your appreciation, you can donate via [PayPal](https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=VBAYDL34Z7J6L) or [cryptocurrency](https://pastebin.com/raw/M2JJpQpC). Thanks!
+
+### Sponsor
+This project is proudly sponsored by our friends at [FrogeHost](https://froge.host/?utm_source=nyr).

--- a/README.md
+++ b/README.md
@@ -8,9 +8,14 @@ This script will let you set up your own VPN server in no more than a minute, ev
 ### Installation
 Run the script and follow the assistant:
 
-`wget https://git.io/vpn -O openvpn-install.sh && bash openvpn-install.sh`
+```
+wget https://git.io/vpn -O openvpn-install.sh && bash openvpn-install.sh
+```
 
 Once it ends, you can run it again to add more users, remove some of them or even completely uninstall OpenVPN.
+
+### Automation
+Check out the script `openvpn-cli.sh` for user management with a single command line, easy to integrate into other scripts or with Ansible or Terraform.
 
 ### I want to run my own VPN but don't have a server for that
 You can get a VPS from just 2€/month at [AlphaVPS](https://alphavps.com/clients/aff.php?aff=474&pid=422).

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -329,7 +329,6 @@ server 10.8.0.0 255.255.255.0" > /etc/openvpn/server/server.conf
 	esac
 	echo 'push "block-outside-dns"' >> /etc/openvpn/server/server.conf
 	echo "keepalive 10 120
-cipher AES-256-CBC
 user nobody
 group $group_name
 persist-key
@@ -429,7 +428,6 @@ persist-key
 persist-tun
 remote-cert-tls server
 auth SHA512
-cipher AES-256-CBC
 ignore-unknown-option block-outside-dns
 verb 3" > /etc/openvpn/server/client-common.txt
 	# Enable and start the OpenVPN service

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -57,8 +57,9 @@ This version of Debian is too old and unsupported."
 fi
 
 if [[ "$os" == "centos" && "$os_version" -lt 9 ]]; then
-	echo "CentOS 9 or higher is required to use this installer.
-This version of CentOS is too old and unsupported."
+	os_name=$(sed 's/ release.*//' /etc/almalinux-release /etc/rocky-release /etc/centos-release 2>/dev/null | head -1)
+	echo "$os_name 9 or higher is required to use this installer.
+This version of $os_name is too old and unsupported."
 	exit
 fi
 

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -237,7 +237,7 @@ LimitNPROC=infinity" > /etc/systemd/system/openvpn-server@server.service.d/disab
 		systemctl enable --now firewalld.service
 	fi
 	# Get easy-rsa
-	easy_rsa_url='https://github.com/OpenVPN/easy-rsa/releases/download/v3.1.7/EasyRSA-3.1.7.tgz'
+	easy_rsa_url='https://github.com/OpenVPN/easy-rsa/releases/download/v3.2.0/EasyRSA-3.2.0.tgz'
 	mkdir -p /etc/openvpn/server/easy-rsa/
 	{ wget -qO- "$easy_rsa_url" 2>/dev/null || curl -sL "$easy_rsa_url" ; } | tar xz -C /etc/openvpn/server/easy-rsa/ --strip-components 1
 	chown -R root:root /etc/openvpn/server/easy-rsa/

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -50,10 +50,16 @@ This version of Ubuntu is too old and unsupported."
 	exit
 fi
 
-if [[ "$os" == "debian" && "$os_version" -lt 9 ]]; then
-	echo "Debian 9 or higher is required to use this installer.
+if [[ "$os" == "debian" ]]; then
+	if grep -q '/sid' /etc/debian_version; then
+		echo "Debian Testing and Debian Unstable are unsupported by this installer."
+		exit
+	fi
+	if [[ "$os_version" -lt 9 ]]; then
+		echo "Debian 9 or higher is required to use this installer.
 This version of Debian is too old and unsupported."
-	exit
+		exit
+	fi
 fi
 
 if [[ "$os" == "centos" && "$os_version" -lt 7 ]]; then

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -14,12 +14,6 @@ fi
 # Discard stdin. Needed when running from an one-liner which includes a newline
 read -N 999999 -t 0.001
 
-# Detect OpenVZ 6
-if [[ $(uname -r | cut -d "." -f 1) -eq 2 ]]; then
-	echo "The system is running an old kernel, which is incompatible with this installer."
-	exit
-fi
-
 # Detect OS
 # $os_version variables aren't always in use, but are kept here for convenience
 if grep -qs "ubuntu" /etc/os-release; then
@@ -44,8 +38,8 @@ Supported distros are Ubuntu, Debian, AlmaLinux, Rocky Linux, CentOS and Fedora.
 	exit
 fi
 
-if [[ "$os" == "ubuntu" && "$os_version" -lt 1804 ]]; then
-	echo "Ubuntu 18.04 or higher is required to use this installer.
+if [[ "$os" == "ubuntu" && "$os_version" -lt 2204 ]]; then
+	echo "Ubuntu 22.04 or higher is required to use this installer.
 This version of Ubuntu is too old and unsupported."
 	exit
 fi
@@ -55,15 +49,15 @@ if [[ "$os" == "debian" ]]; then
 		echo "Debian Testing and Debian Unstable are unsupported by this installer."
 		exit
 	fi
-	if [[ "$os_version" -lt 9 ]]; then
-		echo "Debian 9 or higher is required to use this installer.
+	if [[ "$os_version" -lt 11 ]]; then
+		echo "Debian 11 or higher is required to use this installer.
 This version of Debian is too old and unsupported."
 		exit
 	fi
 fi
 
-if [[ "$os" == "centos" && "$os_version" -lt 7 ]]; then
-	echo "CentOS 7 or higher is required to use this installer.
+if [[ "$os" == "centos" && "$os_version" -lt 9 ]]; then
+	echo "CentOS 9 or higher is required to use this installer.
 This version of CentOS is too old and unsupported."
 	exit
 fi
@@ -231,8 +225,8 @@ LimitNPROC=infinity" > /etc/systemd/system/openvpn-server@server.service.d/disab
 		apt-get update
 		apt-get install -y --no-install-recommends openvpn openssl ca-certificates $firewall
 	elif [[ "$os" = "centos" ]]; then
-		yum install -y epel-release
-		yum install -y openvpn openssl ca-certificates tar $firewall
+		dnf install -y epel-release
+		dnf install -y openvpn openssl ca-certificates tar $firewall
 	else
 		# Else, OS must be Fedora
 		dnf install -y openvpn openssl ca-certificates tar $firewall
@@ -260,7 +254,7 @@ LimitNPROC=infinity" > /etc/systemd/system/openvpn-server@server.service.d/disab
 	# Without +x in the directory, OpenVPN can't run a stat() on the CRL file
 	chmod o+x /etc/openvpn/server/
 	# Generate key for tls-crypt
-	openvpn --genkey --secret /etc/openvpn/server/tc.key
+	openvpn --genkey secret /etc/openvpn/server/tc.key
 	# Create the DH parameters file using the predefined ffdhe2048 group
 	echo '-----BEGIN DH PARAMETERS-----
 MIIBCAKCAQEA//////////+t+FRYortKmq/cViAnPTzx2LnFg84tNpWp4TZBFGQz
@@ -405,13 +399,7 @@ WantedBy=multi-user.target" >> /etc/systemd/system/openvpn-iptables.service
 	if sestatus 2>/dev/null | grep "Current mode" | grep -q "enforcing" && [[ "$port" != 1194 ]]; then
 		# Install semanage if not already present
 		if ! hash semanage 2>/dev/null; then
-			if [[ "$os_version" -eq 7 ]]; then
-				# Centos 7
-				yum install -y policycoreutils-python
-			else
-				# CentOS 8 or Fedora
 				dnf install -y policycoreutils-python-utils
-			fi
 		fi
 		semanage port -a -t openvpn_port_t -p "$protocol" "$port"
 	fi
@@ -553,7 +541,7 @@ else
 					apt-get remove --purge -y openvpn
 				else
 					# Else, OS must be CentOS or Fedora
-					yum remove -y openvpn
+					dnf remove -y openvpn
 					rm -rf /etc/openvpn/server
 				fi
 				echo

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -237,7 +237,7 @@ if [[ ! -e /etc/openvpn/server/server.conf ]]; then
     # Reviewing installation parameters
 	echo "   OpenVPN will bind at $ip on port $port/$protocol"
 	echo "   The public IPv4 (hostname) is $get_public_ip ($public_ip)"
-    if [[ -n $ip6 ]]; then
+	if [[ -n $ip6 ]]; then
 		echo "   The public IPv6 is $ip6"
 	fi
 	echo "   Traffic will be routed via interface $out_interface"

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -234,7 +234,7 @@ if [[ ! -e /etc/openvpn/server/server.conf ]]; then
 			firewall="iptables"
 		fi
 	fi
-    # Reviewing installation parameters
+	# Reviewing installation parameters
 	echo "   OpenVPN will bind at $ip on port $port/$protocol"
 	echo "   The public IPv4 (hostname) is $get_public_ip ($public_ip)"
 	if [[ -n $ip6 ]]; then
@@ -242,7 +242,7 @@ if [[ ! -e /etc/openvpn/server/server.conf ]]; then
 	fi
 	echo "   Traffic will be routed via interface $out_interface"
 	echo "   Names will be resolved by $resolver"
-    echo ''
+	echo ''
 	read -n1 -r -p "Press any key to continue..."
 	# If running inside a container, disable LimitNPROC to prevent conflicts
 	if systemd-detect-virt -cq; then

--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -110,18 +110,18 @@ if [[ ! -e /etc/openvpn/server/server.conf ]]; then
 	clear
 	echo 'Welcome to this OpenVPN road warrior installer!'
 	# Ask the user what IPv4 to use OR to use 0.0.0.0 to listen on all interfaces
-    number_of_real_ip=$(ip -4 addr | grep inet | grep -vEc '127(\.[0-9]{1,3}){3}')
-    number_of_ip=$((number_of_real_ip+1))
-    echo
-    echo "Which IPv4 address should be used?"
-    (ip -4 addr ; echo -n 'inet 0.0.0.0') | grep inet | grep -vE '127(\.[0-9]{1,3}){3}' | cut -d '/' -f 1 | grep -oE '[0-9]{1,3}(\.[0-9]{1,3}){3}' | nl -s ') '
-    read -p "IPv4 address [1]: " ip_number
-    until [[ -z "$ip_number" || "$ip_number" =~ ^[0-9]+$ && "$ip_number" -le "$number_of_ip" ]]; do
-        echo "$ip_number: invalid selection."
-        read -p "IPv4 address [1]: " ip_number
-    done
-    [[ -z "$ip_number" ]] && ip_number="1"
-    ip=$((ip -4 addr ; echo -n 'inet 0.0.0.0') | grep inet | grep -vE '127(\.[0-9]{1,3}){3}' | cut -d '/' -f 1 | grep -oE '[0-9]{1,3}(\.[0-9]{1,3}){3}' | sed -n "$ip_number"p)
+	number_of_real_ip=$(ip -4 addr | grep inet | grep -vEc '127(\.[0-9]{1,3}){3}')
+	number_of_ip=$((number_of_real_ip+1))
+	echo
+	echo "Which IPv4 address should be used?"
+	(ip -4 addr ; echo -n 'inet 0.0.0.0') | grep inet | grep -vE '127(\.[0-9]{1,3}){3}' | cut -d '/' -f 1 | grep -oE '[0-9]{1,3}(\.[0-9]{1,3}){3}' | nl -s ') '
+	read -p "IPv4 address [1]: " ip_number
+	until [[ -z "$ip_number" || "$ip_number" =~ ^[0-9]+$ && "$ip_number" -le "$number_of_ip" ]]; do
+		echo "$ip_number: invalid selection."
+		read -p "IPv4 address [1]: " ip_number
+	done
+	[[ -z "$ip_number" ]] && ip_number="1"
+	ip=$((ip -4 addr ; echo -n 'inet 0.0.0.0') | grep inet | grep -vE '127(\.[0-9]{1,3}){3}' | cut -d '/' -f 1 | grep -oE '[0-9]{1,3}(\.[0-9]{1,3}){3}' | sed -n "$ip_number"p)
 	# If $ip is a private IP address, the server must be behind NAT
 	if echo "$ip" | grep -qE '^(10\.|172\.1[6789]\.|172\.2[0-9]\.|172\.3[01]\.|192\.168|0\.0\.0\.0)'; then
 		echo
@@ -136,8 +136,8 @@ if [[ ! -e /etc/openvpn/server/server.conf ]]; then
 		done
 		[[ -z "$public_ip" ]] && public_ip="$get_public_ip"
 	fi
-    # Seting the default gateway's interface for public side of the NAT since it was used to get_public_ip
-    out_interface=$(ip r | grep -E '^default' | awk '{print $5}')
+	# Seting the default gateway's interface for public side of the NAT since it was used to get_public_ip
+	out_interface=$(ip r | grep -E '^default' | awk '{print $5}')
 	# If system has a single IPv6, it is selected automatically
 	if [[ $(ip -6 addr | grep -c 'inet6 [23]') -eq 1 ]]; then
 		ip6=$(ip -6 addr | grep 'inet6 [23]' | cut -d '/' -f 1 | grep -oE '([0-9a-fA-F]{0,4}:){1,7}[0-9a-fA-F]{0,4}')


### PR DESCRIPTION
While Linode, DigitalOcean, and OVH (**scenario A**) assign the public IP to the virtual machine's network interface, other cloud providers like AWS, GCP, and Azure (**scenario B**) translate the public address (NAT) to the private address on the way in.

Using a hostname (domain/sub-domain) to work around a changed public IP will not work for **scenario A** because the IPv4 is used in the **iptables** for NAT. It is also ineffective when, for any reason, the private IP changes on **scenario B**.

The solution for this problem is to use the default gateway's **interface** instead of the outbound IP in **iptables**. Then, OpenVPN can bind on 0.0.0.0, to accommodate connections independently of the IP.

The use case that required the following changes has been in production for over 2 years, so far:

- I have a fleet of VPN servers that scale in and out according to the demand. I use AWS ASG to increase and decrease the number of servers from a single image. Each new instance will have random private and public IPs.
- I use DNS to select (load balance) a random server for each new connection. The VPN client resolves the hostname only once, right before starting the connection, and uses the IP until the client decides to disconnect.

I am glad to answer any questions. Keep up with the good job!