### PR TITLE
Generate unique DH parameters

### DIFF
--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -256,15 +256,8 @@ LimitNPROC=infinity" > /etc/systemd/system/openvpn-server@server.service.d/disab
 	chmod o+x /etc/openvpn/server/
 	# Generate key for tls-crypt
 	openvpn --genkey secret /etc/openvpn/server/tc.key
-	# Create the DH parameters file using the predefined ffdhe2048 group
-	echo '-----BEGIN DH PARAMETERS-----
-MIIBCAKCAQEA//////////+t+FRYortKmq/cViAnPTzx2LnFg84tNpWp4TZBFGQz
-+8yTnc4kmz75fS/jY2MMddj2gbICrsRhetPfHtXV/WVhJDP1H18GbtCFY2VVPe0a
-87VXE15/V8k1mE8McODmi3fipona8+/och3xWKE2rec1MKzKT0g6eXq8CrGCsyT7
-YdEIqUuyyOP7uWrat2DX9GgdT0Kj3jlN9K5W7edjcrsZCwenyO4KbXCeAvzhzffi
-7MA0BM0oNC9hkXL+nOmFg/+OTxIy7vKBg8P+OxtMb61zO7X8vC7CIAXFjvGDfRaD
-ssbzSibBsu/6iGtCOGEoXJf//////////wIBAg==
------END DH PARAMETERS-----' > /etc/openvpn/server/dh.pem
+	# Generate unique DH parameters with 2048-bit encryption
+	openssl dhparam -out /etc/openvpn/server/dh.pem 2048
 	# Generate server.conf
 	echo "local $ip
 port $port


### PR DESCRIPTION
Generating unique Diffie-Hellman (DH) parameters using OpenSSL enhances security compared to predefined parameters. By creating a new set of DH parameters for each session, the risk of attacks exploiting reused or weak parameters is reduced, ensuring a more secure key exchange process. Although this adds a slight delay to script execution, it is justified by the security improvement of generating unique values for each server.